### PR TITLE
Add setup.py to simplify installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+package = 'pyAudioAnalysis'
+version = '1'
+
+setup(name=package,
+      version=version,
+      url='https://github.com/tyiannak/pyAudioAnalysis')


### PR DESCRIPTION
With this setup.py file the module can be installed with a single command `python setup.py develop` instead of manually changing the pythonpath etc. 