### PR TITLE
Extra declaration of mtFeatures

### DIFF
--- a/audioFeatureExtraction.py
+++ b/audioFeatureExtraction.py
@@ -610,8 +610,6 @@ def mtFeatureExtraction(signal, Fs, mtWin, mtStep, stWin, stStep):
     mtWinRatio = int(round(mtWin / stStep))
     mtStepRatio = int(round(mtStep / stStep))
 
-    mtFeatures = []
-
     stFeatures = stFeatureExtraction(signal, Fs, stWin, stStep)
     numOfFeatures = len(stFeatures)
     numOfStatistics = 2


### PR DESCRIPTION
The empty list was declared twice for no apparent reason.