### PR TITLE
OS specific separator being used.

### DIFF
--- a/audioFeatureExtraction.py
+++ b/audioFeatureExtraction.py
@@ -791,7 +791,7 @@ def dirsWavFeatureExtraction(dirNames, mtWin, mtStep, stWin, stStep, computeBEAT
         if f.shape[0] > 0:       # if at least one audio file has been found in the provided folder:
             features.append(f)
             fileNames.append(fn)
-            if d[-1] == "/":
+            if d[-1] == os.sep:
                 classNames.append(d.split(os.sep)[-2])
             else:
                 classNames.append(d.split(os.sep)[-1])


### PR DESCRIPTION
Shouldn't the comparison be made for the respective path separator in the given operator as opposed to "/" which is hardcoding the separaor.