### PR TITLE
refactor 2 occurences of loadKNNModel to load_model_knn

### DIFF
--- a/pyAudioAnalysis/audioSegmentation.py
+++ b/pyAudioAnalysis/audioSegmentation.py
@@ -698,8 +698,8 @@ def speakerDiarization(fileName, numOfSpeakers, mtSize=2.0, mtStep=0.2, stWin=0.
     x = audioBasicIO.stereo2mono(x)
     Duration = len(x) / Fs
 
-    [Classifier1, MEAN1, STD1, classNames1, mtWin1, mtStep1, stWin1, stStep1, computeBEAT1] = aT.loadKNNModel(os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "knnSpeakerAll"))
-    [Classifier2, MEAN2, STD2, classNames2, mtWin2, mtStep2, stWin2, stStep2, computeBEAT2] = aT.loadKNNModel(os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "knnSpeakerFemaleMale"))
+    [Classifier1, MEAN1, STD1, classNames1, mtWin1, mtStep1, stWin1, stStep1, computeBEAT1] = aT.load_model_knn(os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "knnSpeakerAll"))
+    [Classifier2, MEAN2, STD2, classNames2, mtWin2, mtStep2, stWin2, stStep2, computeBEAT2] = aT.load_model_knn(os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "knnSpeakerFemaleMale"))
 
     [MidTermFeatures, ShortTermFeatures] = aF.mtFeatureExtraction(x, Fs, mtSize * Fs, mtStep * Fs, round(Fs * stWin), round(Fs*stWin * 0.5))
 

--- a/pyAudioAnalysis/audioTrainTest.py
+++ b/pyAudioAnalysis/audioTrainTest.py
@@ -57,7 +57,7 @@ def classifierWrapper(classifier, classifierType, testSample):
     EXAMPLE (for some audio signal stored in array x):
         import audioFeatureExtraction as aF
         import audioTrainTest as aT
-        # load the classifier (here SVM, for kNN use loadKNNModel instead):
+        # load the classifier (here SVM, for kNN use load_model_knn instead):
         [Classifier, MEAN, STD, classNames, mtWin, mtStep, stWin, stStep] = aT.load_model(modelName)
         # mid-term feature extraction:
         [MidTermFeatures, _] = aF.mtFeatureExtraction(x, Fs, mtWin * Fs, mtStep * Fs, round(Fs*stWin), round(Fs*stStep));


### PR DESCRIPTION
When I try to run the speaker diarization example from the [wiki](https://github.com/tyiannak/pyAudioAnalysis/wiki/5.-Segmentation#speaker-diarization)

```
python audioAnalysis.py speakerDiarization -i data/diarizationExample.wav --num 4 
```

I am getting the following error

```
Traceback (most recent call last):
  File "audioAnalysis.py", line 619, in <module>
    speakerDiarizationWrapper(args.input, args.num, args.flsd)
  File "audioAnalysis.py", line 230, in speakerDiarizationWrapper
    aS.speakerDiarization(inputFile, numSpeakers, LDAdim=0, PLOT=True)
  File "[...]/pyAudioAnalysis/audioSegmentation.py", line 701, in speakerDiarization
    [Classifier1, MEAN1, STD1, classNames1, mtWin1, mtStep1, stWin1, stStep1, computeBEAT1] = aT.loadKNNModel(os.path.join(os.path.dirname(os.path.realpath(__file__)), "data", "knnSpeakerAll"))
AttributeError: module 'pyAudioAnalysis.audioTrainTest' has no attribute 'loadKNNModel'
```

Apparently, `aT.loadKNNModel` was refactored to `aT.load_model_knn` in commit c9f688c, but two occurences in audioSegmentation.py were missed. After changing the code accordingly, the wiki example works like a charm.