### PR TITLE
Update audioSegmentation.py to handle ValueError

### DIFF
--- a/pyAudioAnalysis/audioSegmentation.py
+++ b/pyAudioAnalysis/audioSegmentation.py
@@ -747,6 +747,7 @@ def silenceRemoval(x, fs, st_win, st_step, smoothWindow=0.5, weight=0.5, plot=Fa
             plt.axvline(x=s[0])
             plt.axvline(x=s[1])
         plt.subplot(2, 1, 2)
+        prob_on_set = np.insert(prob_on_set, 0, 0)
         plt.plot(np.arange(0, prob_on_set.shape[0] * st_step, st_step), 
                  prob_on_set)
         plt.title('Signal')


### PR DESCRIPTION
`silenceRemoval` throws ValueError when `plot=True` due to difference in dimension for x and y. Propose to add an element with value 0 to extend the length of array.

Error: 
`ValueError: x and y must have same first dimension, but have shapes (193,) and (192,)`

Reference #83