### PR TITLE
adding models to the installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ hmmlearn==0.2.2
 eyeD3==0.8.12
 pydub==0.23.1
 scikit_learn==0.21.3
+tqdm==4.44.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ numpy==1.18.1
 hmmlearn==0.2.2
 eyeD3==0.8.12
 pydub==0.23.1
-pyAudioAnalysis==0.2.5
 scikit_learn==0.21.3

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,9 @@ setup(name='pyAudioAnalysis',
       author_email='tyiannak@gmail.com',
       license='Apache License, Version 2.0',
       packages=['pyAudioAnalysis'],
+      package_data={
+        'pyAudioAnalysis': ['data/models/*']
+      },
       zip_safe=False,
       install_requires=requirements,
       )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 requirements = read('requirements.txt').splitlines()
 
 setup(name='pyAudioAnalysis',
-      version='0.3.0',
+      version='0.3.1',
       description='Python Audio Analysis Library: Feature Extraction, Classification, Segmentation and Applications',
       url='https://github.com/tyiannak/pyAudioAnalysis',
       author='Theodoros Giannakopoulos',


### PR DESCRIPTION
Cloning the code, importing it and running `aS.speakerDiarization` out of the box yields "No such file or directory" on the file `models/knn_speaker_10`.
This tiny fix will copy the models during the installation. 