### PR TITLE
Convert stereo to mono in read_audio_file

### DIFF
--- a/pyAudioAnalysis/audioBasicIO.py
+++ b/pyAudioAnalysis/audioBasicIO.py
@@ -102,8 +102,11 @@ def read_audio_file(input_file):
     else:
         sampling_rate, signal = read_audio_generic(input_file)
 
-    if signal.ndim == 2 and signal.shape[1] == 1:
-        signal = signal.flatten()
+    if signal.ndim == 2:
+        if signal.shape[1] == 1:
+            signal = signal.flatten()
+        elif signal.shape[1] == 2:
+            signal = np.mean(signal, axis=1)
 
     return sampling_rate, signal
 


### PR DESCRIPTION
When trying to train an HMM with your library, I got an error in ShortTermFeatures.py function energy_entropy. It seems that you were assuming that the audio is mono, not stereo, in the line below.

ShortTermFeatures.py, Line 35
frame_length = len(frame)

If the audio is stereo, then frame_length is not equal to the total number of elements in frame, as there are two channels. For example frame_length is 2400 but the frame shape is (2400, 2).

Here is why that was problematic. When I tried running my stereo .wav file through the HMM program, it failed at the following line.

ShortTermFeatures.py, Line 35
sub_wins = frame.reshape(sub_win_len, n_short_blocks, order='F').copy()

To fix this, I changed function read_audio_file audioBasicIO.py, so that it converts stereo to mono by taking the mean of the two channels. This fixed my problem for me, and I hope it will for other people too :)