### PR TITLE
fixed deprecated time.clock()

### DIFF
--- a/pyAudioAnalysis/MidTermFeatures.py
+++ b/pyAudioAnalysis/MidTermFeatures.py
@@ -170,7 +170,7 @@ def directory_feature_extraction(folder_path, mid_window, mid_step,
         if sampling_rate == 0:
             continue        
 
-        t1 = time.clock()        
+        t1 = time.time()        
         signal = audioBasicIO.stereo_to_mono(signal)
         if signal.shape[0] < float(sampling_rate)/5:
             print("  (AUDIO FILE TOO SMALL - SKIPPING)")
@@ -205,7 +205,7 @@ def directory_feature_extraction(folder_path, mid_window, mid_step,
                 mid_term_features = mid_features
             else:
                 mid_term_features = np.vstack((mid_term_features, mid_features))
-            t2 = time.clock()
+            t2 = time.time()
             duration = float(len(signal)) / sampling_rate
             process_times.append((t2 - t1) / duration)
     if len(process_times) > 0:

--- a/pyAudioAnalysis/data/testComputational.py
+++ b/pyAudioAnalysis/data/testComputational.py
@@ -13,66 +13,66 @@ def main(argv):
 		for i in range(nExp):
 			[Fs, x] = audioBasicIO.read_audio_file("diarizationExample.wav");
 			duration = x.shape[0] / float(Fs)
-			t1 = time.clock()
+			t1 = time.time()
 			F = MidTermFeatures.short_term_feature_extraction(x, Fs, 0.050 * Fs, 0.050 * Fs);
-			t2 = time.clock()
+			t2 = time.time()
 			perTime1 =  duration / (t2-t1); print "short-term feature extraction: {0:.1f} x realtime".format(perTime1)
 	elif argv[1] == "-classifyFile":
 		for i in range(nExp):
 			[Fs, x] = audioBasicIO.read_audio_file("diarizationExample.wav");
 			duration = x.shape[0] / float(Fs)		
-			t1 = time.clock()
+			t1 = time.time()
 			aT.file_classification("diarizationExample.wav", "svmSM", "svm")
-			t2 = time.clock()
+			t2 = time.time()
 			perTime1 =  duration / (t2-t1); print "Mid-term feature extraction + classification \t {0:.1f} x realtime".format(perTime1)
 	elif argv[1] == "-mtClassify":
 		for i in range(nExp):
 			[Fs, x] = audioBasicIO.read_audio_file("diarizationExample.wav");
 			duration = x.shape[0] / float(Fs)		
-			t1 = time.clock()
+			t1 = time.time()
 			[flagsInd, classesAll, acc] = aS.mid_term_file_classification("diarizationExample.wav", "svmSM", "svm", False, '')
-			t2 = time.clock()
+			t2 = time.time()
 			perTime1 =  duration / (t2-t1); print "Fix-sized classification - segmentation \t {0:.1f} x realtime".format(perTime1)
 	elif argv[1] == "-hmmSegmentation":
 		for i in range(nExp):
 			[Fs, x] = audioBasicIO.read_audio_file("diarizationExample.wav");
 			duration = x.shape[0] / float(Fs)		
-			t1 = time.clock()
+			t1 = time.time()
 			aS.hmm_segmentation('diarizationExample.wav', 'hmmRadioSM', False, '')             
-			t2 = time.clock()
+			t2 = time.time()
 			perTime1 =  duration / (t2-t1); print "HMM-based classification - segmentation \t {0:.1f} x realtime".format(perTime1)
 	elif argv[1] == "-silenceRemoval":
 		for i in range(nExp):
 			[Fs, x] = audioBasicIO.read_audio_file("diarizationExample.wav");
 			duration = x.shape[0] / float(Fs)				
-			t1 = time.clock()
+			t1 = time.time()
 			[Fs, x] = audioBasicIO.read_audio_file("diarizationExample.wav");
 			segments = aS.silence_removal(x, Fs, 0.050, 0.050, smooth_window= 1.0, Weight = 0.3, plot = False)
-			t2 = time.clock()
+			t2 = time.time()
 			perTime1 =  duration / (t2-t1); print "Silence removal \t {0:.1f} x realtime".format(perTime1)
 	elif argv[1] == "-thumbnailing":
 		for i in range(nExp):
 			[Fs1, x1] = audioBasicIO.read_audio_file("scottish.wav")
 			duration1 = x1.shape[0] / float(Fs1)		
-			t1 = time.clock()
+			t1 = time.time()
 			[A1, A2, B1, B2, Smatrix] = aS.music_thumbnailing(x1, Fs1, 1.0, 1.0, 15.0)	# find thumbnail endpoints
-			t2 = time.clock()
+			t2 = time.time()
 			perTime1 =  duration1 / (t2-t1); print "Thumbnail \t {0:.1f} x realtime".format(perTime1)
 	elif argv[1] == "-diarization-noLDA":
 		for i in range(nExp):
 			[Fs1, x1] = audioBasicIO.read_audio_file("diarizationExample.wav")
 			duration1 = x1.shape[0] / float(Fs1)		
-			t1 = time.clock()		
+			t1 = time.time()		
 			aS.speaker_diarization("diarizationExample.wav", 4, LDAdim = 0, PLOT = False)
-			t2 = time.clock()
+			t2 = time.time()
 			perTime1 =  duration1 / (t2-t1); print "Diarization \t {0:.1f} x realtime".format(perTime1)
 	elif argv[1] == "-diarization-LDA":
 		for i in range(nExp):
 			[Fs1, x1] = audioBasicIO.read_audio_file("diarizationExample.wav")
 			duration1 = x1.shape[0] / float(Fs1)		
-			t1 = time.clock()		
+			t1 = time.time()		
 			aS.speaker_diarization("diarizationExample.wav", 4, PLOT = False)
-			t2 = time.clock()
+			t2 = time.time()
 			perTime1 =  duration1 / (t2-t1); print "Diarization \t {0:.1f} x realtime".format(perTime1)
 		
 if __name__ == '__main__':


### PR DESCRIPTION
`time.clock()` deprecated since Python3.3
[](https://docs.python.org/3.5/library/time.html#time.clock)
Replaced by `time.time()`