### PR TITLE
Fix for Issue 376 about read_audio_generic's signal shape

### DIFF
--- a/pyAudioAnalysis/audioBasicIO.py
+++ b/pyAudioAnalysis/audioBasicIO.py
@@ -150,6 +150,10 @@ def read_audio_generic(input_file):
             signal = np.array(temp_signal).T
     except:
         print("Error: file not found or other I/O error. (DECODING FAILED)")
+
+    if signal.ndim == 2 and signal.shape[1] == 1:
+        signal = signal.flatten()
+    
     return sampling_rate, signal
 
 


### PR DESCRIPTION
This pull request fixes issue #376 .
I know you should use read_audio_file and it will call read_audio_generic if needed and then flatten the signal, but one might end up using the generic function by discovering its existence from hints in an environment such as jupyter notebooks.  
On the other hand this does not break the current behavior of the read_audio_file -> read_audio_generic option.