### PR TITLE
helper function for segment to classfolder , fix #378 and corrected doc-string comment

### DIFF
--- a/pyAudioAnalysis/audacityAnnotation2WAVs.py
+++ b/pyAudioAnalysis/audacityAnnotation2WAVs.py
@@ -28,6 +28,42 @@ def annotation2files(wavFile, csvFile):
             xtemp = x[int(round(T1*Fs)):int(round(T2*Fs))]            
             print(T1, T2, label, xtemp.shape)
             wavfile.write(label, Fs, xtemp)  
+            
+def annotation2folders(wavFile: str, csvFile: str, folderPath: str):
+    """
+        Break an audio stream to segments of interest, 
+        defined by a csv file
+        
+        - wavFile:    path to input wavfile
+        - csvFile:    path to csvFile of segment limits
+        - folderPath: path to class folders
+        
+        Input CSV file must be of the format <T1>\t<T2>\t<Label>
+    """
+    [Fs, x] = audioBasicIO.read_audio_file(wavFile)
+    with open(csvFile, 'r') as csvfile:
+        reader = csv.reader(csvfile, delimiter='\t', quotechar='|')
+        for j, row in enumerate(reader):
+            T1 = float(row[0].replace(",","."))
+            T2 = float(row[1].replace(",","."))
+            label = os.path.join(folderPath, row[2].replace(' ', '_'), "%s_%.2f_%.2f.wav" % (wavFile.split('/')[-1], T1, T2))
+            if not os.path.exists(os.path.join(folderPath, row[2].replace(' ', '_'))):
+                os.makedirs(os.path.join(folderPath, row[2].replace(' ', '_')))
+            label = label.replace(" ", "_")
+            xtemp = x[int(round(T1*Fs)):int(round(T2*Fs))]            
+            print(T1, T2, label, xtemp.shape)
+            wavfile.write(label, Fs, xtemp)
+    
+def folderAnnotation2folders(sourceFolder, targetFolder):
+    """
+        Break an audio stream to segments of interest for all files in the sourceFolder
+        
+        - sourceFolder:    path to Folder of all source audio file and .segments file
+        - targetFolder:    path to Folder where user want to store the class folders
+    """
+    for fileName in glob.glob(os.path.join(sourceFolder, '*.segments')):
+        fileName = fileName.split('.')[0]
+        annotation2folders('%s.wav' % (fileName), '%s.segments' % (fileName), targetFolder)
 
 def main(argv):
     if argv[1] == "-f":

--- a/pyAudioAnalysis/audacityAnnotation2WAVs.py
+++ b/pyAudioAnalysis/audacityAnnotation2WAVs.py
@@ -25,8 +25,7 @@ def annotation2files(wavFile, csvFile):
             T2 = float(row[1].replace(",","."))            
             label = "%s_%s_%.2f_%.2f.wav" % (wavFile, row[2], T1, T2)
             label = label.replace(" ", "_")
-            xtemp = x[int(round(T1*Fs)):int(round(T2*Fs))]            
-            print(T1, T2, label, xtemp.shape)
+            xtemp = x[int(round(T1*Fs)):int(round(T2*Fs))]     
             wavfile.write(label, Fs, xtemp)  
             
 def annotation2folders(wavFile: str, csvFile: str, folderPath: str):
@@ -46,7 +45,7 @@ def annotation2folders(wavFile: str, csvFile: str, folderPath: str):
         for j, row in enumerate(reader):
             T1 = float(row[0].replace(",","."))
             T2 = float(row[1].replace(",","."))
-            label = os.path.join(folderPath, row[2].replace(' ', '_'), "%s_%.2f_%.2f.wav" % (wavFile.split('/')[-1], T1, T2))
+            label = os.path.join(folderPath, row[2].replace(' ', '_'), "%s_%.2f_%.2f.wav" % (os.path.split(wavFile.split)[1], T1, T2))
             if not os.path.exists(os.path.join(folderPath, row[2].replace(' ', '_'))):
                 os.makedirs(os.path.join(folderPath, row[2].replace(' ', '_')))
             label = label.replace(" ", "_")

--- a/pyAudioAnalysis/audacityAnnotation2WAVs.py
+++ b/pyAudioAnalysis/audacityAnnotation2WAVs.py
@@ -50,7 +50,6 @@ def annotation2folders(wavFile: str, csvFile: str, folderPath: str):
                 os.makedirs(os.path.join(folderPath, row[2].replace(' ', '_')))
             label = label.replace(" ", "_")
             xtemp = x[int(round(T1*Fs)):int(round(T2*Fs))]            
-            print(T1, T2, label, xtemp.shape)
             wavfile.write(label, Fs, xtemp)
     
 def folderAnnotation2folders(sourceFolder, targetFolder):

--- a/pyAudioAnalysis/audioSegmentation.py
+++ b/pyAudioAnalysis/audioSegmentation.py
@@ -527,12 +527,16 @@ def mid_term_file_classification(input_file, model_name, model_type,
         - model_type:        svm or knn depending on the classifier type
         - plot_results:      True if results are to be plotted using
                              matplotlib along with a set of statistics
-
+        - gt_file:           path to the ground truth file, if exists, 
+                             for calculating classification performance
     RETURNS:
-          - segs:           a sequence of segment's endpoints: segs[i] is the
-                            endpoint of the i-th segment (in seconds)
-          - classes:        a sequence of class flags: class[i] is the
-                            class ID of the i-th segment
+    labels, class_names, accuracy, cm
+          - labels:         a sequence of segment's labels: segs[i] is the label
+                            of the i-th segment
+          - class_names:    a string sequence of class_names used in classification:
+                            class_names[i] is the name of classes[i]
+          - accuracy:       the accuracy of the classification.
+          - cm:             the confusion matrix of this classification
     """
     labels = []
     accuracy = 0.0

--- a/pyAudioAnalysis/audioTrainTest.py
+++ b/pyAudioAnalysis/audioTrainTest.py
@@ -294,6 +294,8 @@ def extract_features_and_train(paths, mid_window, mid_step, short_window,
     # get optimal classifier parameter:
     temp_features = []
     for feat in features:
+        if feat.ndim == 1: # this class has only 1 sample
+            feat = feat.reshape((1, feat.shape[0]))
         temp = []
         for i in range(feat.shape[0]):
             temp_fv = feat[i, :]


### PR DESCRIPTION
## In audacityAnnotation2WAV.py
I added 2 new functions
- annotation2folders
- folderAnnotation2folders
They can assist us in converting training dataset (raw audio files and .segment files) into fix-sized classifiers usable format: class_name/audio_segments.wav_startTime_endTime.wav
![image](https://user-images.githubusercontent.com/62557955/190888193-439a3347-f093-47e2-a2f9-029fd2b397cc.png)

## In audioTrainTest.py
applied the proposed changes in #378.

## In audioSegmentation.py
Corrected the doc-string comment for ```def mid_term_file_classification()```
Also, for the classification functions, I found it very useful if the variables: segs and classes were returned, which can be used to store desired segmentation results into different folders easily. But due to the huge number of functions needing to be changed, I didn't include them in this pr.
