### PR TITLE
Fix: Issue #396, when chroma features can not be computed

### DIFF
--- a/pyAudioAnalysis/ShortTermFeatures.py
+++ b/pyAudioAnalysis/ShortTermFeatures.py
@@ -290,8 +290,10 @@ def chroma_features(signal, sampling_rate, num_fft):
     else:
         I = np.nonzero(num_chroma > num_chroma.shape[0])[0][0]
         C = np.zeros((num_chroma.shape[0],))
-        C[num_chroma[0:I - 1]] = spec
-        C /= num_freqs_per_chroma
+        if I > 1:
+            # If I <= 1 there are no chroma features that can be extracted
+            C[num_chroma[0:I - 1]] = spec[num_chroma[0:I - 1]]
+            C /= num_freqs_per_chroma
     final_matrix = np.zeros((12, 1))
     newD = int(np.ceil(C.shape[0] / 12.0) * 12)
     C2 = np.zeros((newD,))


### PR DESCRIPTION
Due to issue #396 

Chroma features can not be computed and there are a miss align between shapes in the assignation.

One of the test fails but I am not sure why:

```console
def test_speaker_diarization():
        labels, purity_cluster_m, purity_speaker_m = \
            aS.speaker_diarization("test_data/diarizationExample.wav",
                                    4, plot_res=False)
>       assert purity_cluster_m > 0.9, "Diarization cluster purity is low"
E       AssertionError: Diarization cluster purity is low
E       assert 0.7714285714285715 > 0.9
```